### PR TITLE
Resolve remotes from any server

### DIFF
--- a/bin/ghwd
+++ b/bin/ghwd
@@ -2,19 +2,26 @@
 
 # Figure out github repo base URL
 base_url=$(git config --get remote.origin.url)
-base_url=${base_url%\.git} # remove .git from end of string
 
-# Fix git@github.com: URLs
-base_url=${base_url//git@github\.com:/https:\/\/github\.com\/}
+# Handle no remotes named origin
+# Return the first remote available
+if [[ ! "$base_url" ]]; then
+  remote=$(git remote | tail -n 1)
+  if [[ -z "$remote" ]]; then
+    echo "No remotes available"
+    exit 1
+  fi
+  base_url=$(git config --get "remote.${remote}.url")
+fi
 
-# Fix git://github.com URLS
-base_url=${base_url//git:\/\/github\.com/https:\/\/github\.com\/}
-
-# Fix git@bitbucket.org: URLs
-base_url=${base_url//git@bitbucket.org:/https:\/\/bitbucket\.org\/}
-
-# Fix git@gitlab.com: URLs
-base_url=${base_url//git@gitlab\.com:/https:\/\/gitlab\.com\/}
+# Translate remote to working URL
+if [[ "$base_url" != https://* ]]; then
+  base_url="${base_url#ssh://}"  # remove ssh://
+  base_url="${base_url#git@}"    # remove git@
+  base_url="${base_url/:/\/}"    # replace : with /
+  base_url=${base_url%\.git}     # remove .git from end of string
+  base_url="https://${base_url}" # resolve to HTTPS
+fi
 
 # Validate that this folder is a git folder
 git branch 2>/dev/null 1>&2


### PR DESCRIPTION
Enhances the `base_url` translation to resolve any remote server.

### Tests

Since the executable currently has no Bash functions, it is unreasonable to setup a [bats](https://github.com/sstephenson/bats) test framework. We can instead test a series of remote URIs and test the outcome of translation.

Test with uncommitted change:

```
$ git diff
diff --git a/bin/ghwd b/bin/ghwd
index b53c4e8..ceba1cc 100755
--- a/bin/ghwd
+++ b/bin/ghwd
@@ -23,6 +23,9 @@ if [[ "$base_url" != https://* ]]; then
   base_url="https://${base_url}" # resolve to HTTPS
 fi
 
+echo "$base_url"
+exit
+
 # Validate that this folder is a git folder
 git branch 2>/dev/null 1>&2
 if [ $? -ne 0 ]; then

```

#### Test remotes

Cleanup origin:

```
$ git remote remove origin
```

1. Regular SSH

```
$ git remote add ssh ssh://git@github.com/clintmoyer/ghwd.git
$ ./ghwd
https://github.com/clintmoyer/ghwd

# cleanup
$ git remote remove ssh
```

2. SSH shorthand

```
$ git remote add ssh-shorthand git@github.com:clintmoyer/ghwd.git
$ ./ghwd
https://github.com/clintmoyer/ghwd

# cleanup
$ git remote remove ssh-shorthand
```

3. Regular HTTPS

```
$ git remote add https https://github.com/clintmoyer/ghwd.git
$ ./ghwd
https://github.com/clintmoyer/ghwd

# cleanup
$ git remote remove https
```

4. Custom HTTPS

```
$ git remote add https-custom https://test-url.com/clintmoyer/ghwd.git
$ ./ghwd
https://test-url.com/clintmoyer/ghwd.git

# cleanup
$ git remote remove https-custom
```

5. No remotes

```
$ git remote
[no output]
$ ./ghwd
No remotes available
```